### PR TITLE
[FEAT][RULES] Adjust TypeScript rules to Ubleam's needs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,6 +40,7 @@ module.exports = {
         allowComparingNullableBooleansToFalse: true
       }
     ],
+    "@typescript-eslint/no-inferrable-types": 0,
     "@typescript-eslint/no-unnecessary-condition": 2,
     "@typescript-eslint/prefer-nullish-coalescing": 2,
     "@typescript-eslint/prefer-optional-chain": 2,
@@ -48,7 +49,7 @@ module.exports = {
     "@typescript-eslint/prefer-string-starts-ends-with": 2,
     "@typescript-eslint/promise-function-async": 2,
     "@typescript-eslint/require-array-sort-compare": 2,
-    "@typescript-eslint/strict-boolean-expressions": 2,
+    "@typescript-eslint/strict-boolean-expressions": 0,
     "@typescript-eslint/switch-exhaustiveness-check": 1,
     "@typescript-eslint/typedef": [
       "error",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -60,7 +60,7 @@ module.exports = {
         objectDestructuring: true,
         parameter: true,
         propertyDeclaration: true,
-        variableDeclaration: true,
+        variableDeclaration: false,
         variableDeclarationIgnoreFunction: true
       }
     ],


### PR DESCRIPTION
This PR allows to refine TypeScript rules that we use in our web projects by:

- turning off `@typescript-eslint/strict-boolean-expressions`, because it brings too much null assertions that degrade the readability of the code. 

**Example** : 
```typescript
let str: string | null = null;
if (!str) {
  console.log('str is empty');
}
``` 

should be, according to this rule : 

```typescript
let str: string | null = null;
if (str !== null && !str) {
  console.log('str is empty');
}
```

Given that nullable strings are considered unsafe by default, we must make sure to check nullity if it has been explicitly declared beforehand.

- limiting inferred typing by favoring static typing for some declared values (except variables that are mostly well inferred by TS compiler). 


Signed-off-by: fredericvilcot <fredericvilcot@gmail.com>