### PR TITLE
Update badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 ![build](https://github.com/Ubleam/eslint-config-ubleam/workflows/Build/badge.svg)
 [![npm (scoped)](https://img.shields.io/npm/v/@ubleam/eslint-config)](https://www.npmjs.com/package/@ubleam/eslint-config)
+[![npm bundle size (scoped)](https://img.shields.io/bundlephobia/minzip/@ubleam/eslint-config/latest)](https://bundlephobia.com/result?p=@ubleam/eslint-config@latest)
 ![license](https://img.shields.io/github/license/Ubleam/eslint-config-ubleam?color=blue)
 [![conventional commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 > ESLint [shareable config](https://eslint.org/docs/developer-guide/shareable-configs.html) used @[Ubleam](https://github.com/Ubleam)
 
 ![build](https://github.com/Ubleam/eslint-config-ubleam/workflows/Build/badge.svg)
+[![npm (scoped)](https://img.shields.io/npm/v/@ubleam/eslint-config)](https://www.npmjs.com/package/@ubleam/eslint-config)
 ![license](https://img.shields.io/github/license/Ubleam/eslint-config-ubleam?color=blue)
 [![conventional commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 > ESLint [shareable config](https://eslint.org/docs/developer-guide/shareable-configs.html) used @[Ubleam](https://github.com/Ubleam)
 
-![status](https://img.shields.io/badge/status-👷%20work%20in%20progress-critical)
 ![build](https://github.com/Ubleam/eslint-config-ubleam/workflows/Build/badge.svg)
 ![license](https://img.shields.io/github/license/Ubleam/eslint-config-ubleam?color=blue)
 [![conventional commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)


### PR DESCRIPTION
A minor one that removes the `👷 work in progress` status badge and adds another one for the last published [npm](https://www.npmjs.com/package/@ubleam/eslint-config) version.

----

See:

![image](https://user-images.githubusercontent.com/9574336/108314004-7aea5c80-71b9-11eb-9318-622e0d688018.png)

