### PR TITLE
ci(commitlint): disable commitlint for dependabot

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check commits
+      - if: "(github.actor != 'dependabot[bot]') && !startsWith(github.head_ref, 'dependabot/')"
+        name: Check commits
         uses: wagoid/commitlint-github-action@v2
   build:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
Disable `commitlint` action for `dependabot` PRs in CI because `dependabot` commit messages body line lengths do not conform with `commitlint`'s defaults (100).

Ref. https://github.com/dependabot/dependabot-core/issues/2445
Ref. https://github.com/felipecrs/megatar/pull/105

For instance:

```
Error: You have commit messages with errors
⧗   input: build(deps-dev): bump standard-version from 9.1.0 to 9.1.1
Bumps [standard-version](https://github.com/conventional-changelog/standard-version) from 9.1.0 to 9.1.1.
- [Release notes](https://github.com/conventional-changelog/standard-version/releases)
- [Changelog](https://github.com/conventional-changelog/standard-version/blob/master/CHANGELOG.md)
- [Commits](https://github.com/conventional-changelog/standard-version/compare/v9.1.0...v9.1.1)

Signed-off-by: dependabot[bot] <support@github.com>

✖   body's lines must not be longer than 100 characters [body-max-line-length]

✖   found 1 problems, 0 warnings
ⓘ   Get help: https://github.com/conventional-changelog/commitlint/#what-is-commitlint
```