### PR TITLE
Ci/add npm registry check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,24 +9,16 @@ on:
       - main
 
 jobs:
-  check-commits:
-    runs-on: ubuntu-18.04
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - if: "(github.actor != 'dependabot[bot]') && !startsWith(github.head_ref, 'dependabot/')"
-        name: Check commits
-        uses: wagoid/commitlint-github-action@v2
   build:
     runs-on: ubuntu-18.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
+
       - name: Setup node environment
         uses: actions/setup-node@v1
         with:
           node-version: 14.15.3
-      - run: npm install
+
+      - name: Build
+        run: npm install

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,22 @@
+name: Checks
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-commits:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - if: "(github.actor != 'dependabot[bot]') && !startsWith(github.head_ref, 'dependabot/')"
+        name: Check commits
+        uses: wagoid/commitlint-github-action@v2

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  check-commits:
+  commits-are-conventional:
     runs-on: ubuntu-18.04
     steps:
       - name: Check out repository
@@ -20,3 +20,31 @@ jobs:
       - if: "(github.actor != 'dependabot[bot]') && !startsWith(github.head_ref, 'dependabot/')"
         name: Check commits
         uses: wagoid/commitlint-github-action@v2
+
+  npm-registry-is-public:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Install reviewdog
+        uses: reviewdog/action-setup@v1
+
+      - name: Check
+        shell: bash
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
+        run: |-
+          set -eEu
+          set +o pipefail
+
+          grep -n '"resolved": "' package-lock.json |
+          grep -v "https://registry.npmjs.org/" |
+          sed -E 's/([0-9]+):[^\:]*:[^\"]*\"([^"]+)\"/package-lock.json:\1:Incorrect npm registry \"\2\". Use npm public registry./'  |
+          reviewdog \
+            -efm="%f:%l:%m" \
+            -name="npm-registry-is-public" \
+            -reporter="github-pr-review" \
+            -filter-mode="file" \
+            -fail-on-error="true" \
+            -level="error"


### PR DESCRIPTION
@Ubleam we use a private npm registry for some private projects. So, it may happen by mistake that when adding new dependencies on this project, our private registry is used instead of the public npm one.

To prevent this, the considered PR simply adds a check in the build workflow that ensures that the URLs specified in `package-lock.json` file references the public npm registry URL.

As you'll see, the implementation consists of some basic shell spells (`grep `/ `sed`) followed by a [reviewdog](https://github.com/reviewdog/reviewdog) invocation, the code review 🐶 who keeps codebase health, mainly used here to report issues as a review comment.